### PR TITLE
Add Discord notification workflow for PR events

### DIFF
--- a/.github/workflows/pr-discord-notify.yml
+++ b/.github/workflows/pr-discord-notify.yml
@@ -10,9 +10,10 @@ jobs:
     steps:
       - name: Send notification to Discord
         uses: Ilshidur/action-discord@master
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         with:
-          webhook: ${{ secrets.DISCORD_WEBHOOK }}
-          message: |
+          args: |
             🔔 Pull Request Event:
             • **Action:** ${{ github.event.action }}
             • **Title:** ${{ github.event.pull_request.title }}

--- a/.github/workflows/pr-discord-notify.yml
+++ b/.github/workflows/pr-discord-notify.yml
@@ -1,3 +1,21 @@
+name: Notify Discord on PR Events
+
+on:
+  pull_request:
+    types: [opened, closed, reopened, synchronize]
+
+jobs:
+  discord-notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Discord notification
+        uses: Ilshidur/action-discord@master
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          message: |
+            PR ${{ github.event.pull_request.title }} by ${{ github.actor }}
+            URL: ${{ github.event.pull_request.html_url }}
+            Action: ${{ github.event.action }}
 name: Notify Discord on PR events
 
 on:

--- a/.github/workflows/pr-discord-notify.yml
+++ b/.github/workflows/pr-discord-notify.yml
@@ -1,3 +1,19 @@
+name: Notify Discord on PR events
+
+on:
+  pull_request:
+    types: [opened, closed]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Discord notification
+        run: |
+          curl -H "Content-Type: application/json" \
+          -X POST \
+          -d "{\"content\": \"📢 PR event in *${{ github.repository }}* \n➡️ Title: **${{ github.event.pull_request.title }}** \n✍️ Author: ${{ github.event.pull_request.user.login }} \n🔗 Link: ${{ github.event.pull_request.html_url }} \n📌 Action: ${{ github.event.action }}\"}" \
+          ${{ secrets.DISCORD_WEBHOOK_URL }}
 name: Discord PR Notifications
 
 on:

--- a/.github/workflows/pr-discord-notify.yml
+++ b/.github/workflows/pr-discord-notify.yml
@@ -8,6 +8,29 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
+${{ secrets.DISCORD_WEBHOOK }}name: Notify Discord on PR Events
+
+on:
+  pull_request:
+    types: [opened, closed, reopened, synchronize]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send notification to Discord
+        uses: Ilshidur/action-discord@master
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        with:
+          args: >
+            🚀 **Pull Request #${{ github.event.pull_request.number }}**
+            *${{ github.event.pull_request.title }}*  
+            by **${{ github.actor }}**
+
+            🔗 [View PR](${{ github.event.pull_request.html_url }})  
+            📂 Repository: ${{ github.repository }}  
+            📌 Action: ${{ github.event.action }}
       - name: Send Discord notification
         run: |
           curl -H "Content-Type: application/json" \

--- a/.github/workflows/pr-discord-notify.yml
+++ b/.github/workflows/pr-discord-notify.yml
@@ -1,0 +1,21 @@
+name: Discord PR Notifications
+
+on:
+  pull_request:
+    types: [opened, closed, reopened]
+
+jobs:
+  notify-discord:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send notification to Discord
+        uses: Ilshidur/action-discord@v2
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          message: |
+            🔔 New PR Event:
+            • **Action:** ${{ github.event.action }}
+            • **Title:** ${{ github.event.pull_request.title }}
+            • **Author:** ${{ github.actor }}
+            • **URL:** ${{ github.event.pull_request.html_url }}
+

--- a/.github/workflows/pr-discord-notify.yml
+++ b/.github/workflows/pr-discord-notify.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send notification to Discord
-        uses: Ilshidur/action-discord@v2
+	uses: Ilshidur/action-discord@master
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
           message: |

--- a/.github/workflows/pr-discord-notify.yml
+++ b/.github/workflows/pr-discord-notify.yml
@@ -1,65 +1,8 @@
-name: Notify Discord on PR Events
-
-on:
-  pull_request:
-    types: [opened, closed, reopened, synchronize]
-
-jobs:
-  discord-notify:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Send Discord notification
-        uses: Ilshidur/action-discord@master
-        with:
-          webhook: ${{ secrets.DISCORD_WEBHOOK }}
-          message: |
-            PR ${{ github.event.pull_request.title }} by ${{ github.actor }}
-            URL: ${{ github.event.pull_request.html_url }}
-            Action: ${{ github.event.action }}
-name: Notify Discord on PR events
-
-on:
-  pull_request:
-    types: [opened, closed]
-
-jobs:
-  notify:
-    runs-on: ubuntu-latest
-    steps:
-${{ secrets.DISCORD_WEBHOOK }}name: Notify Discord on PR Events
-
-on:
-  pull_request:
-    types: [opened, closed, reopened, synchronize]
-
-jobs:
-  notify:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Send notification to Discord
-        uses: Ilshidur/action-discord@master
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
-        with:
-          args: >
-            🚀 **Pull Request #${{ github.event.pull_request.number }}**
-            *${{ github.event.pull_request.title }}*  
-            by **${{ github.actor }}**
-
-            🔗 [View PR](${{ github.event.pull_request.html_url }})  
-            📂 Repository: ${{ github.repository }}  
-            📌 Action: ${{ github.event.action }}
-      - name: Send Discord notification
-        run: |
-          curl -H "Content-Type: application/json" \
-          -X POST \
-          -d "{\"content\": \"📢 PR event in *${{ github.repository }}* \n➡️ Title: **${{ github.event.pull_request.title }}** \n✍️ Author: ${{ github.event.pull_request.user.login }} \n🔗 Link: ${{ github.event.pull_request.html_url }} \n📌 Action: ${{ github.event.action }}\"}" \
-          ${{ secrets.DISCORD_WEBHOOK_URL }}
 name: Discord PR Notifications
 
 on:
   pull_request:
-    types: [opened, closed, reopened]
+    types: [opened, closed, reopened, synchronize]
 
 jobs:
   notify-discord:
@@ -70,7 +13,7 @@ jobs:
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
           message: |
-            🔔 New PR Event:
+            🔔 Pull Request Event:
             • **Action:** ${{ github.event.action }}
             • **Title:** ${{ github.event.pull_request.title }}
             • **Author:** ${{ github.actor }}

--- a/.github/workflows/pr-discord-notify.yml
+++ b/.github/workflows/pr-discord-notify.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send notification to Discord
-	uses: Ilshidur/action-discord@master
+        uses: Ilshidur/action-discord@master
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
           message: |

--- a/workflow_test.txt
+++ b/workflow_test.txt
@@ -1,0 +1,1 @@
+Testing workflow automation


### PR DESCRIPTION
Description
This pull request adds a GitHub Actions workflow that sends notifications to a Discord channel whenever a pull request is opened or reopened.
It ensures better visibility of repository activity for the team.